### PR TITLE
parser crash fixed

### DIFF
--- a/src/objectscript.cpp
+++ b/src/objectscript.cpp
@@ -7621,6 +7621,11 @@ OS::Core::Compiler::Expression * OS::Core::Compiler::expectFunctionSugarExpressi
 		}else{
 			last_exp_exists = false;
 		}
+        if(!recent_token)
+        { // TODO: add more intellectual error reporting???
+            setError(Tokenizer::END_CODE_BLOCK, exp->token); // use last expression token
+            break;
+        }
 		TokenType token_type = recent_token->type;
 		if(token_type == Tokenizer::CODE_SEPARATOR){
 			if(!readToken()){


### PR DESCRIPTION
parsing this code OS crashed:
var f = {|| echo("c = ${c}");
var c = 3;
echo(f());
return;
String.__add = {|v| this .. v;}
