### PR TITLE
libobjectscript, CMake fixes, README enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ win/ipch/
 *.sdf
 *.suo
 *.vcxproj.user
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,15 @@ project(ObjectScript)
 set(BUILD_SHARED OFF)
 
 # This is the base of ObjectScript.
-set(OSBASE_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/objectscript.cpp
+set(OSBASE_HDR
     ${CMAKE_CURRENT_SOURCE_DIR}/src/objectscript.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/os-heap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/os-heap.h
 )
+set(OSBASE_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/os-heap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/objectscript.cpp
+)
 file(GLOB OSBASE_BINDER "${CMAKE_CURRENT_SOURCE_DIR}/src/os-binder*.h")
-add_library(osbase ${OSBASE_SRC} ${OSBASE_BINDER})
-# target_include_directories(osbase PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-set_property(TARGET osbase APPEND PROPERTY INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Used later
 set(DEFLIST "")
@@ -250,9 +249,19 @@ else()
 endif()
 
 
+# Create a libobjectscript for other apps to link against.
+add_library(objectscript STATIC
+    ${OSBASE_SRC}
+    ${OSBASE_HDR}
+    ${OSBASE_BINDER}
+    ${EXT_SRC}
+    ${GLOB_EXT_BASE}
+    ${GLOB_EXT_HASH}
+)
+
 # Now its time to put stuff in place
 # First, OS-FCGI
-add_executable(os-fcgi os-fcgi.cpp ${EXT_SRC} ${GLOB_EXT_BASE} ${GLOB_EXT_HASH})
+add_executable(os-fcgi os-fcgi.cpp)
 set_property(TARGET os-fcgi APPEND PROPERTY INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(os-fcgi
     ${CMAKE_THREAD_LIBS_INIT}
@@ -265,11 +274,11 @@ target_link_libraries(os-fcgi
     dl
     mpfd
     fcgi
-    osbase
+    objectscript
 )
 
 # Now, standalone OS
-add_executable(os os.cpp ${EXT_SRC} ${GLOB_EXT_BASE} ${GLOB_EXT_HASH})
+add_executable(os os.cpp)
 set_property(TARGET os APPEND PROPERTY INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(os
     ${CURL_LIBRARIES}
@@ -280,7 +289,7 @@ target_link_libraries(os
     ${EXT_LIBS}
     dl
     mpfd
-    osbase
+    objectscript
 )
 
 # Short additions:
@@ -351,6 +360,9 @@ include_directories("${PROJECT_BINARY_DIR}")
 # Install `os` and `os-fcgi`:
 # Windows users must do this on their own.
 if(UNIX)
-    install(TARGETS os os-fcgi  DESTINATION bin)
+    install(TARGETS os-fcgi  DESTINATION sbin)
+    install(TARGETS os  DESTINATION bin)
+    install(TARGETS objectscript DESTINATION lib)
+    install(FILES ${OSBASE_HDR} ${OSBASE_BINDER} DESTINATION include)
     install(DIRECTORY conf/etc/ DESTINATION /etc)
 endif()

--- a/README.md
+++ b/README.md
@@ -48,6 +48,41 @@ cd build
 
 This will update all the binaries within your build folder and make them find the library - hopefuly.
 
+Using ObjectScript in your app
+====================
+
+After installing ObjectScript, you also will get the required headers into your system to utilize ObjectScript in your app. This is especially useful to let the user do something within your app. Here is an example:
+
+app.cpp:
+```cpp
+#include <objectscript.h>
+
+using namespace ObjectScript;
+
+int main(int argc, char** argv) {
+	OS* os = OS::create();
+
+	// simulate calling "print()" with given argv
+	os->getGlobal("print");
+	os->newArray(argc);
+	for(int i=0; i<argc; i++) {
+		os->pushString(argv[i]);
+		os->addProperty(-2);
+	}
+	os->callF(1);
+}
+```
+
+Now, compile it just like this:
+
+    g++ app.cpp -o app -lobjectscript
+
+To do so on Windows, copy the resulting `libobjectscript.lib` and `src/objectscript.h` to your project, and compile as:
+
+    cl app.cpp libobjectscript.lib /I. /Fe:app
+
+The library and headers are installed globally into your installation path's `include` folder.
+
 Nginx config example (for __os-fcgi__)
 ====================
 

--- a/conf/etc/init.d/os-fcgi
+++ b/conf/etc/init.d/os-fcgi
@@ -7,7 +7,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=os-fcgi
-DAEMON=/usr/sbin/$NAME
+DAEMON="$(which $NAME)"
 DESC="ObjectScript FastCGI Process Manager"
 USER=www-data
 GROUP=www-data


### PR DESCRIPTION
- libobjectscript and proper headers are installed now.
- Added a note to README to give an example on how to use ObjectScript using the minimal libobjectscript.
- `os-fcgi` service now uses the `which` command to search for `os-fcgi`, which is now installed into the `sbin` folder of the installation path. Default is `/usr/local`.